### PR TITLE
Fix for  #22

### DIFF
--- a/gnomonicus/gnomonicus_lib.py
+++ b/gnomonicus/gnomonicus_lib.py
@@ -1040,7 +1040,7 @@ def saveJSON(variants, mutations, effects, path: str, guid: str, catalogue: piez
                 row['ref'] = mutation['ref'] if pd.notnull(mutation['ref']) else None
                 row['alt'] = mutation['alt'] if pd.notnull(mutation['alt']) else None
             _mutations.append(row)
-        data['mutations'] = _mutations
+    data['mutations'] = _mutations
 
     _effects = defaultdict(list)
     antibiogram = {}
@@ -1066,12 +1066,12 @@ def saveJSON(variants, mutations, effects, path: str, guid: str, catalogue: piez
             _effects[drug].append({'phenotype': phenotype})
             antibiogram[drug] = phenotype
             drugs.add(drug)
-        data['effects'] = _effects
+    data['effects'] = _effects
     if catalogue is not None:
         for d in catalogue.catalogue.drugs:
             if d not in drugs:
                 antibiogram[d] = "S"
-        data['antibiogram'] = antibiogram
+    data['antibiogram'] = antibiogram
 
     #Convert fields to a list so it can be json serialised
     with open(os.path.join(path, f'{guid}.gnomonicus-out.json'), 'w') as f:

--- a/tests/unit/test_unit.py
+++ b/tests/unit/test_unit.py
@@ -350,7 +350,7 @@ def test_1():
     recursive_eq(ordered(expectedJSON), ordered(actualJSON))
 
     #Running the same test again, but with no catalogue
-    #Should just produce variants and mutations sections of the JSON
+    #Should just produce variants and mutations sections of the JSON with empty sections for effects+antibiogram
     setupOutput('1')
     gnomonicus.populateVariants(vcfStem, path, diff, True, False)
     mutations, referenceGenes = gnomonicus.populateMutations(vcfStem, path, diff, 
@@ -405,6 +405,8 @@ def test_1():
                     "alt": "aaa"
                 }
             ],
+            'effects': {},
+            'antibiogram': {}
         }
     }
     expectedJSON = json.loads(json.dumps(expectedJSON, sort_keys=True))


### PR DESCRIPTION
Added fix to ensure `mutations` and `effects` are always populated within the JSON, even if empty