### PR TITLE
Added pushing to OCR as well as dockerhub for GPAS

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -29,6 +29,13 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
       -
+        name: Login to OCR
+        uses: docker/login-action@v1 
+        with:
+          registry: lhr.ocir.io
+          username: ${{ secrets.OCR_USERNAME }}
+          password: ${{ secrets.OCR_TOKEN }}
+      -
         name: Build and push
         id: docker_build
         uses: docker/build-push-action@v2
@@ -37,5 +44,7 @@ jobs:
           tags: |
             oxfordmmm/gnomonicus:latest
             oxfordmmm/gnomonicus:${{steps.gnomonicus.outputs.tag}}
+            lhr.ocir.io/lrbvkel2wjot/oxfordmmm/gnomonicus:latest
+            lhr.ocir.io/lrbvkel2wjot/oxfordmmm/gnomonicus:${{steps.gnomonicus.outputs.tag}}
           push: true
           no-cache: true


### PR DESCRIPTION
Ensure that OCR containers are also pushed to ensure that GPAS pipelines have access to the latest releases