### PR TITLE
Added error handling to temporarily appease oxfordmmm/gumpy#24

### DIFF
--- a/bin/gnomonicus
+++ b/bin/gnomonicus
@@ -119,7 +119,7 @@ if __name__ == "__main__":
     variants = populateVariants(vcfStem, options.output_dir, diff, make_variants_csv, options.resistance_genes, catalogue=resistanceCatalogue)
     logging.debug("Populated and saved variants.csv")
 
-    mutations, referenceGenes = populateMutations(vcfStem, options.output_dir, diff, 
+    mutations, referenceGenes, minor_errors = populateMutations(vcfStem, options.output_dir, diff, 
                         reference, sample, resistanceCatalogue, make_mutations_csv, options.resistance_genes)
     if mutations is None:
         logging.info("No mutations found - probably due to exclusively inter-gene variation or no variation.\n\t\t\t\t\t\t\t No effects.csv written")
@@ -158,7 +158,7 @@ if __name__ == "__main__":
         if values is None:
             values = list("RFUS")
         logging.info(f"Saving a JSON... See {options.output_dir}/gnomonicus-out.json")
-        saveJSON(variants, mutations, effects, options.output_dir, vcfStem, resistanceCatalogue, gnomonicus.__version__, time.time()-start, reference, options.vcf_file, options.genome_object, options.catalogue_file)
+        saveJSON(variants, mutations, effects, options.output_dir, vcfStem, resistanceCatalogue, gnomonicus.__version__, time.time()-start, reference, options.vcf_file, options.genome_object, options.catalogue_file, minor_errors)
 
     if options.fasta and options.fasta.lower() in ['fixed', 'variable']:
         fixed = options.fasta.lower() == 'fixed'

--- a/gnomonicus/gnomonicus_lib.py
+++ b/gnomonicus/gnomonicus_lib.py
@@ -12,6 +12,8 @@ import logging
 import os
 import pickle
 import re
+import traceback
+import warnings
 from collections import defaultdict
 from collections.abc import Iterable
 
@@ -20,6 +22,7 @@ import numpy as np
 import pandas as pd
 import piezo
 from tqdm import tqdm
+
 
 class InvalidMutationException(Exception):
     '''Custom exception raised when an invalid mutation is detected
@@ -287,7 +290,7 @@ def getGenes(diff: gumpy.GenomeDifference, resistanceCatalogue: piezo.Resistance
 
 def populateMutations(
         vcfStem: str, outputDir: str, diff: gumpy.GenomeDifference, reference: gumpy.Genome,
-        sample: gumpy.Genome, resistanceCatalogue: piezo.ResistanceCatalogue, make_csv: bool, resistanceGenesOnly: bool) -> (pd.DataFrame, dict):
+        sample: gumpy.Genome, resistanceCatalogue: piezo.ResistanceCatalogue, make_csv: bool, resistanceGenesOnly: bool) -> (pd.DataFrame, dict, dict):
     '''Popuate and save the mutations DataFrame as a CSV, then return it for use in predictions
 
     Args:
@@ -385,8 +388,10 @@ def populateMutations(
     #Add minor mutations (these are stored separately)
     if reference.minor_populations or sample.minor_populations:
         #Only do this if they exist
-        x = minority_population_mutations(diffs, resistanceCatalogue)
+        x, errors = minority_population_mutations(diffs, resistanceCatalogue)
         mutations = pd.concat([mutations, x])
+    else:
+        errors = {}
     #If there were mutations, write them to a CSV
     if mutations is not None:
 
@@ -415,7 +420,7 @@ def populateMutations(
             #Save it as CSV
             mutations_.to_csv(os.path.join(outputDir, f'{vcfStem}.mutations.csv'), index=False)
 
-    return mutations, referenceGenes
+    return mutations, referenceGenes, errors
 
 def minority_population_variants(diff: gumpy.GenomeDifference, catalogue: piezo.ResistanceCatalogue, genes: set[str]) -> pd.DataFrame:
     '''Handle the logic for pulling out minority population calls for genome level variants
@@ -627,7 +632,7 @@ def minority_population_variants(diff: gumpy.GenomeDifference, catalogue: piezo.
                                 })
 
 
-def minority_population_mutations(diffs: [gumpy.GeneDifference], catalogue: piezo.ResistanceCatalogue) -> pd.DataFrame:
+def minority_population_mutations(diffs: [gumpy.GeneDifference], catalogue: piezo.ResistanceCatalogue) -> (pd.DataFrame, dict):
     '''Handle the logic for pulling out minority population calls for gene level variants
 
     Args:
@@ -658,12 +663,20 @@ def minority_population_mutations(diffs: [gumpy.GeneDifference], catalogue: piez
     variants = []
     number_nucleotide_changes = []
 
+    #Track errors (if any) for reporting but not throwing
+    errors = {}
+
     #Determine if FRS or COV should be used
     minor_type = get_minority_population_type(catalogue)
 
     for diff in diffs:
         #As mutations returns in GARC, split into constituents for symmetry with others
-        mutations = diff.minor_populations(interpretation=minor_type)
+        try:
+            mutations = diff.minor_populations(interpretation=minor_type)
+        except Exception as e:
+            warnings.warn(f"An error occurred within {diff.gene2.name}! Check JSON for stack trace.")
+            errors[diff.gene2.name] = traceback.format_exc()
+            continue
         
         #Without gene names/evidence
         muts = [ mut.split(":")[0]for mut in mutations]
@@ -764,7 +777,7 @@ def minority_population_mutations(diffs: [gumpy.GeneDifference], catalogue: piez
                                         'amino_acid_number': 'float',
                                         'amino_acid_sequence': 'str',
                                         'number_nucleotide_changes': 'int'
-                                    })
+                                    }), errors
 
 def getMutations(mutations: pd.DataFrame, catalogue: piezo.catalogue, referenceGenes: dict) -> [[str, str]]:
     '''Get all of the mutations (including multi-mutations) from the mutations df
@@ -922,7 +935,7 @@ def populateEffects(
     #Return  the metadata dict to log later
     return effects, {"WGS_PREDICTION_"+drug: phenotype[drug] for drug in resistanceCatalogue.catalogue.drugs}
 
-def saveJSON(variants, mutations, effects, path: str, guid: str, catalogue: piezo.ResistanceCatalogue, gnomonicusVersion: str, time_taken: float, reference: gumpy.Genome, vcf_path: str, reference_path: str, catalogue_path: str) -> None:
+def saveJSON(variants, mutations, effects, path: str, guid: str, catalogue: piezo.ResistanceCatalogue, gnomonicusVersion: str, time_taken: float, reference: gumpy.Genome, vcf_path: str, reference_path: str, catalogue_path: str, minor_errors: dict) -> None:
     '''Create and save a single JSON output file for use within GPAS. JSON structure:
     {
         'meta': {
@@ -940,6 +953,9 @@ def saveJSON(variants, mutations, effects, path: str, guid: str, catalogue: piez
             'reference_file': Path to the reference file,
             'vcf_file': Path to the VCF file
         },
+        ?'errors': {
+            <gene name>: <stack trace>
+        }
         'data': {
             'variants': [
                 {
@@ -992,6 +1008,7 @@ def saveJSON(variants, mutations, effects, path: str, guid: str, catalogue: piez
         vcf_path (str): Path to the VCF file used for this run
         reference_path (str): Path to the reference genome used for this run
         catalogue_path (str): Path to the catalogue used for this run
+        minor_errors (dict): Mapping of gene name --> stack trace of any errors occurring when parsing minor mutations
     '''
     values = catalogue.catalogue.values if catalogue is not None else list("RFUS")
     #Define some metadata for the json
@@ -1081,5 +1098,9 @@ def saveJSON(variants, mutations, effects, path: str, guid: str, catalogue: piez
 
     #Convert fields to a list so it can be json serialised
     with open(os.path.join(path, f'{guid}.gnomonicus-out.json'), 'w') as f:
-        f.write(json.dumps({'meta': meta, 'data': data}, indent=2))
+        #Add errors (if any)
+        if len(minor_errors) > 0:
+            f.write(json.dumps({'meta': meta, 'data': data, 'errors': minor_errors}, indent=2))
+        else:
+            f.write(json.dumps({'meta': meta, 'data': data}, indent=2))
 

--- a/tests/unit/test_unit.py
+++ b/tests/unit/test_unit.py
@@ -175,11 +175,11 @@ def test_misc():
     #Populate the tables
     path = "tests/outputs/0/"
     gnomonicus.populateVariants(vcfStem, path, diff, False, False)
-    mutations, referenceGenes = gnomonicus.populateMutations(vcfStem, path, diff, 
+    mutations, referenceGenes, errors = gnomonicus.populateMutations(vcfStem, path, diff, 
                                     reference, sample, catalogue, False, False)
     
     #Check for differences if a catalogue is not given. Should be the same mutations but different referenceGenes
-    mutations_, referenceGenes_ = gnomonicus.populateMutations(vcfStem, path, diff, 
+    mutations_, referenceGenes_, errors = gnomonicus.populateMutations(vcfStem, path, diff, 
                                     reference, sample, None, False, False)
     
     assert mutations.equals(mutations_)
@@ -249,7 +249,7 @@ def test_1():
     #Populate the tables
     path = "tests/outputs/1/"
     gnomonicus.populateVariants(vcfStem, path, diff, True, False)
-    mutations, referenceGenes = gnomonicus.populateMutations(vcfStem, path, diff, 
+    mutations, referenceGenes, errors = gnomonicus.populateMutations(vcfStem, path, diff, 
                                     reference, sample, catalogue, True, False)
     gnomonicus.populateEffects(path, catalogue, mutations, referenceGenes, vcfStem, True, True)
 
@@ -283,7 +283,7 @@ def test_1():
             hits.append(None)
     assert sorted(hits) == ['AAA', 'BBB']
 
-    gnomonicus.saveJSON(variants, mutations, effects, path, vcfStem, catalogue, gnomonicus.__version__, -1, reference, '', '', '')
+    gnomonicus.saveJSON(variants, mutations, effects, path, vcfStem, catalogue, gnomonicus.__version__, -1, reference, '', '', '', {})
 
     expectedJSON = {
         'meta': {
@@ -353,7 +353,7 @@ def test_1():
     #Should just produce variants and mutations sections of the JSON with empty sections for effects+antibiogram
     setupOutput('1')
     gnomonicus.populateVariants(vcfStem, path, diff, True, False)
-    mutations, referenceGenes = gnomonicus.populateMutations(vcfStem, path, diff, 
+    mutations, referenceGenes, errors = gnomonicus.populateMutations(vcfStem, path, diff, 
                                     reference, sample, None, True, False)
     gnomonicus.populateEffects(path, None, mutations, referenceGenes, vcfStem, True, True)
 
@@ -366,7 +366,7 @@ def test_1():
     with pytest.raises(Exception):
         predictions = pd.read_csv(path + f"{vcfStem}.predictions.csv")
 
-    gnomonicus.saveJSON(variants, mutations, None, path, vcfStem, None, gnomonicus.__version__, -1, reference, '', '', '')
+    gnomonicus.saveJSON(variants, mutations, None, path, vcfStem, None, gnomonicus.__version__, -1, reference, '', '', '', {})
 
     expectedJSON = {
         'meta': {
@@ -441,7 +441,7 @@ def test_2():
     #Populate the tables
     path = "tests/outputs/2/"
     gnomonicus.populateVariants(vcfStem, path, diff, True, False)
-    mutations, referenceGenes = gnomonicus.populateMutations(vcfStem, path, diff, 
+    mutations, referenceGenes, errors = gnomonicus.populateMutations(vcfStem, path, diff, 
                                     reference, sample, catalogue, True, False)
     gnomonicus.populateEffects(path, catalogue, mutations, referenceGenes, vcfStem, True, True)
 
@@ -475,7 +475,7 @@ def test_2():
             hits.append(None)
     assert sorted(hits) == ['AAA', 'BBB']
 
-    gnomonicus.saveJSON(variants, mutations, effects, path, vcfStem, catalogue, gnomonicus.__version__, -1, reference, '', '', '')
+    gnomonicus.saveJSON(variants, mutations, effects, path, vcfStem, catalogue, gnomonicus.__version__, -1, reference, '', '', '', {})
 
     expectedJSON = {
         'meta': {
@@ -576,7 +576,7 @@ def test_3():
     #Populate the tables
     path = "tests/outputs/3/"
     gnomonicus.populateVariants(vcfStem, path, diff, True, False)
-    mutations_, referenceGenes = gnomonicus.populateMutations(vcfStem, path, diff, 
+    mutations_, referenceGenes, errors = gnomonicus.populateMutations(vcfStem, path, diff, 
                                     reference, sample, catalogue, True, False)
     gnomonicus.populateEffects(path, catalogue, mutations_, referenceGenes, vcfStem, True, True)
 
@@ -610,7 +610,7 @@ def test_3():
             hits.append(None)
     assert sorted(hits) == ['AAA', 'BBB']
 
-    gnomonicus.saveJSON(variants, mutations_, effects, path, vcfStem, catalogue, gnomonicus.__version__, -1, reference, '', '', '')
+    gnomonicus.saveJSON(variants, mutations_, effects, path, vcfStem, catalogue, gnomonicus.__version__, -1, reference, '', '', '', {})
 
     expectedJSON = {
         'meta': {
@@ -722,7 +722,7 @@ def test_4():
     #Populate the tables
     path = "tests/outputs/4/"
     gnomonicus.populateVariants(vcfStem, path, diff, True, False)
-    mutations, referenceGenes = gnomonicus.populateMutations(vcfStem, path, diff, 
+    mutations, referenceGenes, errors = gnomonicus.populateMutations(vcfStem, path, diff, 
                                     reference, sample, catalogue, True, False)
     gnomonicus.populateEffects(path, catalogue, mutations, referenceGenes, vcfStem, True, True)
 
@@ -756,7 +756,7 @@ def test_4():
             hits.append(None)
     assert sorted(hits) == ['AAA', 'BBB']
 
-    gnomonicus.saveJSON(variants, mutations, effects, path, vcfStem, catalogue, gnomonicus.__version__, -1, reference, '', '', '')
+    gnomonicus.saveJSON(variants, mutations, effects, path, vcfStem, catalogue, gnomonicus.__version__, -1, reference, '', '', '', {})
 
     expectedJSON = {
         'meta': {
@@ -863,7 +863,7 @@ def test_5():
     #Populate the tables
     path = "tests/outputs/5/"
     gnomonicus.populateVariants(vcfStem, path, diff, True, False)
-    mutations, referenceGenes = gnomonicus.populateMutations(vcfStem, path, diff, 
+    mutations, referenceGenes, errors = gnomonicus.populateMutations(vcfStem, path, diff, 
                                     reference, sample, catalogue, True, False)
     gnomonicus.populateEffects(path, catalogue, mutations, referenceGenes, vcfStem, True, True)
 
@@ -902,7 +902,7 @@ def test_5():
             hits.append(None)
     assert sorted(hits) == ['AAA', 'BBB']
 
-    gnomonicus.saveJSON(variants, mutations, effects, path, vcfStem, catalogue, gnomonicus.__version__, -1, reference, '', '', '')
+    gnomonicus.saveJSON(variants, mutations, effects, path, vcfStem, catalogue, gnomonicus.__version__, -1, reference, '', '', '', {})
 
     expectedJSON = {
         'meta': {
@@ -1006,7 +1006,7 @@ def test_6():
     #Populate the tables
     path = "tests/outputs/6/"
     gnomonicus.populateVariants(vcfStem, path, diff, True, False)
-    mutations, referenceGenes = gnomonicus.populateMutations(vcfStem, path, diff, 
+    mutations, referenceGenes, errors = gnomonicus.populateMutations(vcfStem, path, diff, 
                                     reference, sample, catalogue, True, False)
     gnomonicus.populateEffects(path, catalogue, mutations, referenceGenes, vcfStem, True, True)
 
@@ -1047,7 +1047,7 @@ def test_6():
             hits.append(None)
     assert sorted(hits) == ['AAA', 'BBB']
 
-    gnomonicus.saveJSON(variants, mutations, effects, path, vcfStem, catalogue, gnomonicus.__version__, -1, reference, '', '', '')
+    gnomonicus.saveJSON(variants, mutations, effects, path, vcfStem, catalogue, gnomonicus.__version__, -1, reference, '', '', '', {})
 
     expectedJSON = {
         'meta': {
@@ -1199,7 +1199,7 @@ def test_7():
     #Populate the tables
     path = "tests/outputs/7/"
     gnomonicus.populateVariants(vcfStem, path, diff, True, False)
-    mutations, referenceGenes = gnomonicus.populateMutations(vcfStem, path, diff, 
+    mutations, referenceGenes, errors = gnomonicus.populateMutations(vcfStem, path, diff, 
                                     reference, sample, catalogue, True, False)
     gnomonicus.populateEffects(path, catalogue, mutations, referenceGenes, vcfStem, True, True)
 
@@ -1249,7 +1249,7 @@ def test_7():
             hits.append(None)
     assert sorted(hits) == ['AAA', 'BBB']
 
-    gnomonicus.saveJSON(variants, mutations, effects, path, vcfStem, catalogue, gnomonicus.__version__, -1, reference, '', '', '')
+    gnomonicus.saveJSON(variants, mutations, effects, path, vcfStem, catalogue, gnomonicus.__version__, -1, reference, '', '', '', {})
 
     expectedJSON = {
         'meta': {
@@ -1409,7 +1409,7 @@ def test_8():
     #Populate the tables
     path = "tests/outputs/8/"
     gnomonicus.populateVariants(vcfStem, path, diff, True, False)
-    mutations, referenceGenes = gnomonicus.populateMutations(vcfStem, path, diff, 
+    mutations, referenceGenes, errors = gnomonicus.populateMutations(vcfStem, path, diff, 
                                     reference, sample, catalogue, True, False)
     gnomonicus.populateEffects(path, catalogue, mutations, referenceGenes, vcfStem, True, True)
 
@@ -1443,7 +1443,7 @@ def test_8():
             hits.append(None)
     assert sorted(hits) == ['AAA', 'BBB']
 
-    gnomonicus.saveJSON(variants, mutations, effects, path, vcfStem, catalogue, gnomonicus.__version__, -1, reference, '', '', '')
+    gnomonicus.saveJSON(variants, mutations, effects, path, vcfStem, catalogue, gnomonicus.__version__, -1, reference, '', '', '', {})
 
     expectedJSON = {
         'meta': {
@@ -1553,7 +1553,7 @@ def test_9():
     #Populate the tables
     path = "tests/outputs/9/"
     gnomonicus.populateVariants(vcfStem, path, diff, True, False)
-    mutations, referenceGenes = gnomonicus.populateMutations(vcfStem, path, diff, 
+    mutations, referenceGenes, errors = gnomonicus.populateMutations(vcfStem, path, diff, 
                                     reference, sample, catalogue, True, False)
     gnomonicus.populateEffects(path, catalogue, mutations, referenceGenes, vcfStem, True, True)
 
@@ -1597,7 +1597,7 @@ def test_9():
             hits.append(None)
     assert sorted(hits) == ['AAA', 'BBB']
 
-    gnomonicus.saveJSON(variants, mutations, effects, path, vcfStem, catalogue, gnomonicus.__version__, -1, reference, '', '', '')
+    gnomonicus.saveJSON(variants, mutations, effects, path, vcfStem, catalogue, gnomonicus.__version__, -1, reference, '', '', '', {})
 
     expectedJSON = {
         'meta': {
@@ -1825,7 +1825,7 @@ def test_10():
     #Populate the tables
     path = "tests/outputs/10/"
     gnomonicus.populateVariants(vcfStem, path, diff, True, False, catalogue=catalogue)
-    mutations, referenceGenes = gnomonicus.populateMutations(vcfStem, path, diff, 
+    mutations, referenceGenes, errors = gnomonicus.populateMutations(vcfStem, path, diff, 
                                     reference, sample, catalogue, True, False)
     gnomonicus.populateEffects(path, catalogue, mutations, referenceGenes, vcfStem, True, True)
     
@@ -1870,7 +1870,7 @@ def test_10():
             hits.append(None)
     assert sorted(hits) == ['AAA', 'BBB']
 
-    gnomonicus.saveJSON(variants, mutations, effects, path, vcfStem, catalogue, gnomonicus.__version__, -1, reference, '', '', '')
+    gnomonicus.saveJSON(variants, mutations, effects, path, vcfStem, catalogue, gnomonicus.__version__, -1, reference, '', '', '', {})
 
     expectedJSON = {
         'meta': {
@@ -2097,7 +2097,7 @@ def test_11():
     #Populate the tables
     path = "tests/outputs/11/"
     gnomonicus.populateVariants(vcfStem, path, diff, True, False, catalogue=catalogue)
-    mutations, referenceGenes = gnomonicus.populateMutations(vcfStem, path, diff, 
+    mutations, referenceGenes, errors = gnomonicus.populateMutations(vcfStem, path, diff, 
                                     reference, sample, catalogue, True, False)
     gnomonicus.populateEffects(path, catalogue, mutations, referenceGenes, vcfStem, True, True)
     
@@ -2141,7 +2141,7 @@ def test_11():
             hits.append(None)
     assert sorted(hits) == ['AAA']
 
-    gnomonicus.saveJSON(variants, mutations, effects, path, vcfStem, catalogue, gnomonicus.__version__, -1, reference, '', '', '')
+    gnomonicus.saveJSON(variants, mutations, effects, path, vcfStem, catalogue, gnomonicus.__version__, -1, reference, '', '', '', {})
 
     expectedJSON = {
         'meta': {


### PR DESCRIPTION
Adds a warning, and tracks whenever an exception occurs while getting the minor populations at a gene level. Warning is printed, and the error is added to the JSON in an `error` block - mapping the gene it affects to the stack trace of the error