### PR TITLE
Fix to ensure that multis aren't erroneously duplicated

### DIFF
--- a/gnomonicus/gnomonicus_lib.py
+++ b/gnomonicus/gnomonicus_lib.py
@@ -796,7 +796,7 @@ def getMutations(mutations: pd.DataFrame, catalogue: piezo.catalogue, referenceG
     #Grab the multi-mutations from the catalogue
     #By doing this, we can check a fixed sample space rather than every permutation of the mutations
     #This makes the problem tractable, but does not address a possible issue with multi-mutations not encapsulating full codons
-    multis = catalogue.catalogue.rules[catalogue.catalogue.rules['MUTATION_TYPE']=='MULTI']['MUTATION']
+    multis = set(catalogue.catalogue.rules[catalogue.catalogue.rules['MUTATION_TYPE']=='MULTI']['MUTATION'])
     if len(multis) > 0:
         #We have a catalogue including multi rules, so check if any of these are present in the mutations
         joined = [gene+'@'+mut for (gene, mut) in mutations]

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = gnomonicus
-version = 2.1.2
+version = 2.1.3
 author = Philip W Fowler, Jeremy Westhead
 author_email = philip.fowler@ndm.ox.ac.uk
 description = Python code to integrate results of tb-pipeline and provide an antibiogram, mutations and variants


### PR DESCRIPTION
If a catalogue has the same multi mutation prediction for multiple drugs, this mutation would be duplicated for each drug. This lead to the outputs producing duplicate entries in the JSON for these mutations. Example JSON snippet:
```
{
          "gene": null,
          "mutation": "fabG1@I109I&fabG1@c327t",
          "prediction": "U",
          "evidence": {}
        },
        {
          "gene": null,
          "mutation": "fabG1@F72F&fabG1@c216t",
          "prediction": "U",
          "evidence": {}
        },
        {
          "gene": null,
          "mutation": "fabG1@I109I&fabG1@c327t",
          "prediction": "U",
          "evidence": {}
        },
        {
          "gene": null,
          "mutation": "fabG1@F72F&fabG1@c216t",
          "prediction": "U",
          "evidence": {}
        },
```
This should simply fix this by treating the multi mutations from the catalogue as a set before fetching them from the genome