### PR TITLE
fix: ensure fasta adjudicated mutations get all predictions

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = gnomonicus
-version = 2.3.6
+version = 2.3.7
 author = Philip W Fowler, Jeremy Westhead
 author_email = philip.fowler@ndm.ox.ac.uk
 description = Python code to integrate results of tb-pipeline and provide an antibiogram, mutations and variants


### PR DESCRIPTION
Accidentally pushed to main on this one so added a branch protection rule. Should bump the version before release for commit [fix: ensure fasta adjudicated mutations get all predictions](https://github.com/oxfordmmm/gnomonicus/commit/8ffba930646f95646e3744f0e09377eca6b230d6)