### PR TITLE
fix(update-table): ensure append on outputDir

### DIFF
--- a/bin/gnomonicus-table-update
+++ b/bin/gnomonicus-table-update
@@ -22,7 +22,7 @@ if __name__ == "__main__":
         required=False,
         help="Path to the resistance catalogue",
     )
-    parser.add_argument("--output", default=".", help="Output path. WILL OVERWRITE FILES!!")
+    parser.add_argument("--output", default=".", help="Output path")
     parser.add_argument("--progress", action="store_true", default=False, help="Show progress bar")
     options = parser.parse_args()
 

--- a/gnomonicus/gnomonicus_lib.py
+++ b/gnomonicus/gnomonicus_lib.py
@@ -1404,7 +1404,9 @@ def populateEffects(
             if append:
                 # Check to see if there's anything there already
                 try:
-                    old_effects = pd.read_csv(os.path.join(outputDir, f"{vcfStem}.effects.csv"))
+                    old_effects = pd.read_csv(
+                        os.path.join(outputDir, f"{vcfStem}.effects.csv")
+                    )
                     effects_df = pd.concat([old_effects, effects_df])
                 except FileNotFoundError:
                     pass
@@ -1430,7 +1432,9 @@ def populateEffects(
         if append:
             # Check to see if there's anything there already
             try:
-                old_predictions = pd.read_csv(os.path.join(outputDir, f"{vcfStem}.predictions.csv"))
+                old_predictions = pd.read_csv(
+                    os.path.join(outputDir, f"{vcfStem}.predictions.csv")
+                )
                 predictions_df = pd.concat([old_predictions, predictions_df])
             except FileNotFoundError:
                 pass

--- a/gnomonicus/gnomonicus_lib.py
+++ b/gnomonicus/gnomonicus_lib.py
@@ -1404,7 +1404,7 @@ def populateEffects(
             if append:
                 # Check to see if there's anything there already
                 try:
-                    old_effects = pd.read_csv(f"{vcfStem}.effects.csv")
+                    old_effects = pd.read_csv(os.path.join(outputDir, f"{vcfStem}.effects.csv"))
                     effects_df = pd.concat([old_effects, effects_df])
                 except FileNotFoundError:
                     pass
@@ -1430,7 +1430,7 @@ def populateEffects(
         if append:
             # Check to see if there's anything there already
             try:
-                old_predictions = pd.read_csv(f"{vcfStem}.predictions.csv")
+                old_predictions = pd.read_csv(os.path.join(outputDir, f"{vcfStem}.predictions.csv"))
                 predictions_df = pd.concat([old_predictions, predictions_df])
             except FileNotFoundError:
                 pass


### PR DESCRIPTION
Previously, appending was checked from `<foo>-effects.csv` rather than the file which is written to `<outputDir>/<foo>-effects.csv`. This should ensure that the file is appended if outputDir is set