### PR TITLE
fix: ensure docker build runs

### DIFF
--- a/environments/Dockerfile
+++ b/environments/Dockerfile
@@ -7,4 +7,4 @@ RUN apt update && apt install -y git python3 python3-pip s3fs
 # RUN git clone https://github.com/oxfordmmm/gnomonicus && cd gnomonicus && pip install .
 
 #Install gnomonicus from pypi
-RUN pip install --upgrade gnomonicus
+RUN pip install --upgrade gnomonicus --break-system-packages

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = gnomonicus
-version = 2.5.4
+version = 2.5.5
 author = Philip W Fowler, Jeremy Westhead
 author_email = philip.fowler@ndm.ox.ac.uk
 description = Python code to integrate results of tb-pipeline and provide an antibiogram, mutations and variants


### PR DESCRIPTION
This is a fun quirk of using the latest ubuntu image - the python version got bumped to a new version which doesn't allow installing python packages outside of a virtual environment by default. The added flag should bypass this (although it looks scary). Tested building locally and it seems to work fine
Also bumps the release version