### PR TITLE
fix: ensure all minos positions from merge-vcfs

### DIFF
--- a/bin/merge-vcfs
+++ b/bin/merge-vcfs
@@ -15,7 +15,7 @@ def fetch_minos_positions(minos_vcf: Path) -> set[int]:
     Returns:
         set[int]: The positions to exclude.
     """
-    vcf = gumpy.VCFFile(minos_vcf.as_posix())
+    vcf = gumpy.VCFFile(minos_vcf.as_posix(), ignore_filter=True)
     positions = set()
     for pos, m_type in vcf.calls:
         if m_type != "indel":
@@ -28,6 +28,7 @@ def fetch_minos_positions(minos_vcf: Path) -> set[int]:
                 positions.add(pos)
             else:
                 positions.update(range(pos, pos + len(bases)))
+    print(len(positions))
     return positions
             
 
@@ -65,7 +66,7 @@ if __name__ == "__main__":
     # Pull out these positions from the GVCF
     gvcf_headers, subset = subset_vcf(gvcf_path.as_posix(), to_fetch)
 
-    minos_headers, minos_values = subset_vcf(minos_path.as_posix(), sorted(list(minos_positions)))
+    minos_headers, minos_values = subset_vcf(minos_path.as_posix(), [])
     
     # Pull out header parts to catch parts which need adding
     minos_format = [header for header in minos_headers if "##FORMAT" in header]

--- a/bin/merge-vcfs
+++ b/bin/merge-vcfs
@@ -28,7 +28,6 @@ def fetch_minos_positions(minos_vcf: Path) -> set[int]:
                 positions.add(pos)
             else:
                 positions.update(range(pos, pos + len(bases)))
-    print(len(positions))
     return positions
             
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = gnomonicus
-version = 2.6.0
+version = 2.6.1
 author = Philip W Fowler, Jeremy Westhead
 author_email = philip.fowler@ndm.ox.ac.uk
 description = Python code to integrate results of tb-pipeline and provide an antibiogram, mutations and variants
@@ -18,6 +18,7 @@ python_requires = >=3.10
 install_requires = 
     gumpy>=1.3.0
     piezo>=0.8.3
+    vcf_subset>=1.1.1
     numpy
     pandas
     recursive_diff


### PR DESCRIPTION
`merge-vcfs` was removing rows from the minos VCF which had filter fails, as well as deletion rows (as these don't start at the position of the deletion)
Corresponding change to `vcf_subset` was used to return **all** vcf rows if you pass an empty list 