### PR TITLE
fix: make sure duplicate rows can't make it through

### DIFF
--- a/bin/merge-vcfs
+++ b/bin/merge-vcfs
@@ -110,7 +110,11 @@ if __name__ == "__main__":
         f.write(chrom_line + "\n")
 
         # Minos rows
+        minos_positions = []
         for row in minos_values:
+            r = row.split("\t")
+            pos = int(r[1])
+            minos_positions.append(pos)
             f.write(row + "\n")
             
         # GVCF rows
@@ -122,6 +126,12 @@ if __name__ == "__main__":
                 row = row.replace("\tDP:", "\tCOV:")
 
             row = row.split("\t")
+            pos = int(row[1])
+            if pos in minos_positions:
+                # We should already be filtering out positions, but in cases of dels, the start can slip through
+                # Catch duplicates in these cases
+                continue
+            
             # GVCF doesn't explicitly call filter passes, so ensure the calls are picked up
             row[6] = "PASS" if row[6] == "." else row[6]
             f.write("\t".join(row) + "\n")

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = gnomonicus
-version = 2.6.1
+version = 2.6.2
 author = Philip W Fowler, Jeremy Westhead
 author_email = philip.fowler@ndm.ox.ac.uk
 description = Python code to integrate results of tb-pipeline and provide an antibiogram, mutations and variants


### PR DESCRIPTION
This is the cause of this failure https://dev.portal.gpas.world/samples/37fd971f-d17f-4e28-91f7-718c3268f075
Essentially fetching the positions from the minos ignored an edge case where deletions could make it through; especially problematic as deletions are populated in the gvcf too. `gumpy` errors on duplicate positions, so this should filter out any rows already in the minos