### PR TITLE
fix: if a gvcf row has a COV field, don't use DP

### DIFF
--- a/bin/merge-vcfs
+++ b/bin/merge-vcfs
@@ -121,10 +121,11 @@ if __name__ == "__main__":
         # GVCF rows
         for row in subset:
             # Replace DP with COV as GVCF doesn't have a COV-like field
-            if ":DP" in row:
-                row = row.replace(":DP", ":COV")
-            elif "\tDP:" in row:
-                row = row.replace("\tDP:", "\tCOV:")
+            if ":COV" not in row and "\tCOV:" not in row:
+                if ":DP" in row:
+                    row = row.replace(":DP", ":COV")
+                elif "\tDP:" in row:
+                    row = row.replace("\tDP:", "\tCOV:")
 
             row = row.split("\t")
             pos = int(row[1])

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = gnomonicus
-version = 2.6.6
+version = 2.6.8
 author = Philip W Fowler, Jeremy Westhead
 author_email = philip.fowler@ndm.ox.ac.uk
 description = Python code to integrate results of tb-pipeline and provide an antibiogram, mutations and variants


### PR DESCRIPTION
Sundial's `final.full.vcf` which is a proxy for clockwork's `gvcf` doesn't use the same fields. Gvcf lacks a COV field, instead using DP for this. Sundial, being more sane, uses DP to mean total depth and has a COV field already.
Before this, sundial's DP field was overriding with COV, and `pysam`'s parsing treated both as the first value (which didn't have expected values)

This didn't cause an error though as this is technically fine and a valid VCF. It did however cause issues around merged in rows with expected minor populations (which rely on the COV field to be found)