### PR TITLE
bump: vcf_subset 2.0.0

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = gnomonicus
-version = 3.0.0
+version = 3.0.1
 author = Philip W Fowler, Jeremy Westhead
 author_email = philip.fowler@ndm.ox.ac.uk
 description = Python code to integrate results of tb-pipeline and provide an antibiogram, mutations and variants

--- a/setup.cfg
+++ b/setup.cfg
@@ -19,7 +19,7 @@ install_requires =
     gumpy>=1.3.8
     bio-grumpy>=0.2.0
     piezo>=0.8.4
-    vcf_subset>=1.1.2
+    vcf_subset>=2.0.0
     numpy
     pandas
     recursive_diff

--- a/setup.cfg
+++ b/setup.cfg
@@ -17,7 +17,7 @@ packages = find:
 python_requires = >=3.10
 install_requires = 
     gumpy>=1.3.8
-    bio-grumpy>=0.2.0
+    bio-grumpy>=0.2.1
     piezo>=0.8.4
     vcf_subset>=2.0.0
     numpy


### PR DESCRIPTION
Tests will fail until https://github.com/GlobalPathogenAnalysisService/vcf_subset/pull/1 is merged and released