### PR TITLE
fix: significant speed increase for `merge-vcfs`

### DIFF
--- a/gnomonicus/merge_vcfs.py
+++ b/gnomonicus/merge_vcfs.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python3
 """Merge a minos VCF with a GVCF at certain positions (driven by the catalogue).
 Will only include null calls from the GVCF.
 """
@@ -22,8 +21,7 @@ def fetch_minos_positions(minos_path: Path, min_dp: int) -> set[int]:
     """
     vcf = grumpy.VCFFile(minos_path.as_posix(), False, min_dp)
     positions: set[int] = set()
-    for position in vcf.calls.keys():
-        calls = vcf.calls[position]
+    for position, calls in vcf.calls.items():
         for call in calls:
             if call.call_type == grumpy.AltType.DEL:
                 # Deletion - need to exclude all bases deleted
@@ -48,8 +46,8 @@ def check_gvcf_row(row: str, min_dp: int) -> bool:
         f.write(row + "\n")
     vcf = grumpy.VCFFile(".temp_gvcf_row.vcf", False, min_dp)
     valid = True
-    for position in vcf.calls:
-        for call in vcf.calls[position]:
+    for position, calls in vcf.calls.items():
+        for call in calls:
             if call.call_type != grumpy.AltType.NULL:
                 valid = False
     Path(".temp_gvcf_row.vcf").unlink()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "gnomonicus"
-version = "3.1.0"
+version = "3.1.1"
 description = "Python code to integrate results of tb-pipeline and provide an antibiogram, mutations and variants"
 authors = [
     { name = "Jeremy Westhead", email = "jeremy.westhead@ndm.ox.ac.uk" },


### PR DESCRIPTION
Theory is that for some reason when Python was indexing `vcf.calls[position]`, it was cloning either the entire `vcf.calls` or the entire `vcf` object, leading to each iteration taking ~0.05s. Just iterating the `.items()` avoids this - making each iteration ~10^-7s