### PR TITLE
Multiple catalogues

### DIFF
--- a/gnomonicus/__init__.py
+++ b/gnomonicus/__init__.py
@@ -26,10 +26,10 @@ __version__ = importlib.metadata.version("gnomonicus")
 
 from .gnomonicus_lib import (
     InvalidMutationException,  # noqa: F401
-    populateEffects,  # noqa: F401
     get_minority_population_type,  # noqa: F401
+    getGenes,  # noqa: F401
+    populateEffects,  # noqa: F401
     populateMutations,  # noqa: F401
     populateVariants,  # noqa: F401
     saveJSON,  # noqa: F401
-    getGenes,  # noqa: F401
 )

--- a/gnomonicus/gnomonicus.py
+++ b/gnomonicus/gnomonicus.py
@@ -237,7 +237,7 @@ def main():
                 make_prediction_csv,
                 reference,
                 make_mutations_csv=make_mutations_csv,
-                append=True
+                append=True,
             )
             if len(resistanceCatalogue) > 1:
                 # Add catalogue name to the phenotype dictionary to distinguish between catalogues

--- a/gnomonicus/gnomonicus.py
+++ b/gnomonicus/gnomonicus.py
@@ -10,8 +10,8 @@ import os
 import time
 
 import grumpy
-import piezo
 import pandas as pd
+import piezo
 
 import gnomonicus
 from gnomonicus import (
@@ -185,7 +185,7 @@ def main():
     # Complain if there are no variants
     if diff.variants is None:
         logging.error("No variants detected!")
-        raise Exception("No variants detected!")
+        raise Exception("No variants detected!")  # noqa: TRY002
 
     # Get the variations and mutations
     variants = populateVariants(

--- a/gnomonicus/gnomonicus.py
+++ b/gnomonicus/gnomonicus.py
@@ -11,6 +11,7 @@ import time
 
 import grumpy
 import piezo
+import pandas as pd
 
 import gnomonicus
 from gnomonicus import (
@@ -43,6 +44,7 @@ def main():
         "--catalogue_file",
         default=None,
         required=False,
+        nargs="+",
         help="the path to the resistance catalogue",
     )
     parser.add_argument(
@@ -137,6 +139,7 @@ def main():
             "[WARNING]: No outputs selected. No files will be created. For help, try `gnomonicus --help`"
         )
         logging.warning("No outputs selected. No files will be created")
+        return
 
     # Get reference genome
     reference = grumpy.Genome(options.genome_object)
@@ -150,12 +153,19 @@ def main():
     )
 
     # Get resistance catalogue
-    if options.catalogue_file:
-        resistanceCatalogue = piezo.ResistanceCatalogue(
-            options.catalogue_file, prediction_subset_only=options.resistance_genes
-        )
+    if options.catalogue_file is not None:
+        resistanceCatalogue = [
+            piezo.ResistanceCatalogue(
+                catalogue, prediction_subset_only=options.resistance_genes
+            )
+            for catalogue in options.catalogue_file
+        ]
         logging.debug("Loaded resistance catalogue")
-        minor_type = gnomonicus.get_minority_population_type(resistanceCatalogue)
+        minor_types = [
+            gnomonicus.get_minority_population_type(catalogue)
+            for catalogue in resistanceCatalogue
+        ]
+        minor_type = minor_types[0]
     else:
         resistanceCatalogue = None
         logging.info(
@@ -163,7 +173,7 @@ def main():
         )
         # Default to COV if no resistance catalogue is provided
         # not that it needs to be used, but minor populations are built into grumpy
-        minor_type = grumpy.MinorType.COV
+        minor_type = [grumpy.MinorType.COV]
 
     sample = grumpy.mutate(reference, vcf)
     logging.debug("Applied the VCF to the reference")
@@ -185,7 +195,7 @@ def main():
         make_variants_csv,
         options.resistance_genes,
         sample,
-        catalogue=resistanceCatalogue,
+        catalogue=resistanceCatalogue[0] if resistanceCatalogue is not None else None,
     )
     logging.debug("Populated and saved variants.csv")
 
@@ -195,7 +205,7 @@ def main():
         diff,
         reference,
         sample,
-        resistanceCatalogue,
+        resistanceCatalogue[0] if resistanceCatalogue is not None else None,
         make_mutations_csv,
         options.resistance_genes,
     )
@@ -208,17 +218,40 @@ def main():
 
     # Get the effects and predictions of the mutations
     if resistanceCatalogue is not None:
-        effects, phenotypes, mutations = populateEffects(
-            options.output_dir,
-            resistanceCatalogue,
-            mutations,
-            vcfStem,
-            make_effects_csv,
-            make_prediction_csv,
-            reference,
-            make_mutations_csv=make_mutations_csv,
-        )
-        logging.debug("Populated and saved effects.csv and predictions.csv")
+        phenotypes = {}
+        effects_ = []
+        mutations_ = []
+        for idx, catalogue in enumerate(resistanceCatalogue):
+            if minor_types[idx] != minor_type:
+                logging.warning(
+                    f"Minor population type for catalogue {catalogue.catalogue.name} ({minor_types[idx]}) does not match the minor population type used to build the genome difference ({minor_type}). Re-running the genome difference with the correct minor population type."
+                )
+                diff = grumpy.GenomeDifference(reference, sample, minor_types[idx])
+                minor_type = minor_types[idx]
+            these_effects, pheno, these_mutations = populateEffects(
+                options.output_dir,
+                catalogue,
+                mutations,
+                vcfStem,
+                make_effects_csv,
+                make_prediction_csv,
+                reference,
+                make_mutations_csv=make_mutations_csv,
+                append=True
+            )
+            if len(resistanceCatalogue) > 1:
+                # Add catalogue name to the phenotype dictionary to distinguish between catalogues
+                for drug in pheno:
+                    phenotypes[f"{drug} {catalogue.catalogue.name}"] = pheno[drug]
+            else:
+                phenotypes = pheno
+            logging.debug(
+                f"Populated and saved effects.csv and predictions.csv for {catalogue.catalogue.name}"
+            )
+            effects_.append(these_effects)
+            mutations_.append(these_mutations)
+        effects = pd.concat(effects_, ignore_index=True)
+        mutations = pd.concat(mutations_, ignore_index=True)
     else:
         phenotypes = {}
         effects = None
@@ -233,27 +266,21 @@ def main():
     logging.info(f"Reference genome file: {options.genome_object}")
 
     if resistanceCatalogue:
-        logging.info(
-            f"Catalogue reference genome: {resistanceCatalogue.catalogue.genbank_reference}"
-        )
-        logging.info(f"Catalogue name: {resistanceCatalogue.catalogue.name}")
-        logging.info(f"Catalogue version: {resistanceCatalogue.catalogue.version}")
-        logging.info(f"Catalogue grammar: {resistanceCatalogue.catalogue.grammar}")
-        logging.info(f"Catalogue values: {resistanceCatalogue.catalogue.values}")
-        logging.info(f"Catalogue path: {options.catalogue_file}")
+        logging.info(f"Ran with {len(resistanceCatalogue)} resistance catalogue(s)")
+        for idx, catalogue in enumerate(resistanceCatalogue):
+            logging.info(
+                f"Catalogue {idx+1} reference genome: {catalogue.catalogue.genbank_reference}"
+            )
+            logging.info(f"Catalogue {idx+1} name: {catalogue.catalogue.name}")
+            logging.info(f"Catalogue {idx+1} version: {catalogue.catalogue.version}")
+            logging.info(f"Catalogue {idx+1} grammar: {catalogue.catalogue.grammar}")
+            logging.info(f"Catalogue {idx+1} values: {catalogue.catalogue.values}")
+            logging.info(f"Catalogue {idx+1} path: {options.catalogue_file}")
     for drug in sorted(phenotypes.keys()):
         logging.info(f"{drug} {phenotypes[drug]}")
     logging.info(f"Completed in {time.time()-start}s")
 
     if options.json:
-        # Default prediction values are RFUS but use piezo catalogue's values if existing
-        values = (
-            resistanceCatalogue.catalogue.values
-            if resistanceCatalogue is not None
-            else None
-        )
-        if values is None:
-            values = list("RFUS")
         logging.info(f"Saving a JSON... See {options.output_dir}/gnomonicus-out.json")
         saveJSON(
             variants,

--- a/gnomonicus/gnomonicus_lib.py
+++ b/gnomonicus/gnomonicus_lib.py
@@ -1134,7 +1134,8 @@ def saveJSON(
                         'gene': Gene name of the mutation,
                         'mutation': Gene level mutation in GARC,
                         'prediction': Prediction caused by this mutation,
-                        'evidence': Evidence to support this prediction. Currently placeholder
+                        'evidence': Evidence to support this prediction,
+                        ?'catalogue_name': Name of the catalogue used to make this prediction. Populated if >1 catalogue is used,
                     }, ...,
                     {
                         'phenotype': Resultant prediction for this drug based on prediciton heirarchy
@@ -1176,21 +1177,39 @@ def saveJSON(
             "vcf_file": vcf_path,
         }
     )
+    valid_values = True
     if catalogue is not None:
-        meta["catalogue_type"] = "".join(catalogue.catalogue.values)
-        meta["catalogue_name"] = catalogue.catalogue.name
-        meta["catalogue_version"] = catalogue.catalogue.version
+        if len(catalogue) == 1:
+            meta["catalogue_type"] = "".join(catalogue[0].catalogue.values)
+            meta["catalogue_name"] = catalogue[0].catalogue.name
+            meta["catalogue_version"] = catalogue[0].catalogue.version
+            values = list(catalogue[0].catalogue.values)
+        else:
+            meta["catalogue_type"] = [
+                "".join(cat.catalogue.values) for cat in catalogue
+            ]
+            meta["catalogue_name"] = [cat.catalogue.name for cat in catalogue]
+            meta["catalogue_version"] = [cat.catalogue.version for cat in catalogue]
+            values = list(catalogue[0].catalogue.values)
+            # Quick check that all catalogues have the same values or we will have issues with the antibiogram
+            for cat in catalogue:
+                if list(cat.catalogue.values) != values:
+                    logging.error(
+                        "Multiple catalogues used with different prediction values. The overall predicted phenotypes will be null!"
+                    )
+                    valid_values = False
     else:
         meta["catalogue_type"] = None
         meta["catalogue_name"] = None
         meta["catalogue_version"] = None
+        values = []
 
     # Main data collection
     data: Dict = OrderedDict()
 
     # Antibigram field
     data["antibiogram"] = OrderedDict(
-        [(key, phenotypes[key]) for key in sorted(phenotypes.keys())]
+        [(drug, phenotypes[drug]) for drug in sorted(phenotypes.keys())]
     )
 
     # Variants field
@@ -1280,6 +1299,8 @@ def saveJSON(
                     "evidence": effect["evidence"],
                 }
             )
+            if catalogue is not None and len(catalogue) > 1:
+                prediction["catalogue_name"] = effect["catalogue_name"]
             _effects[effect["drug"]].append(prediction)
 
     for drug in _effects.keys():
@@ -1287,7 +1308,44 @@ def saveJSON(
             _effects[drug],
             key=lambda x: (x["gene"] or "z", x["mutation"] or "z"),
         )
-        _effects[drug].append(OrderedDict({"phenotype": phenotypes[drug]}))
+        if len(catalogue) == 1:
+            _effects[drug].append(OrderedDict({"phenotype": phenotypes[drug]}))
+        else:
+            # Multiple catalogues, so give phenotypes for each catalogue
+            _effects[drug].append(
+                OrderedDict(
+                    {
+                        "phenotypes": [
+                            f'{phenotypes[f"{drug} {cat.catalogue.name}"]} {cat.catalogue.name}'
+                            for cat in catalogue
+                            if drug in cat.catalogue.drugs
+                        ]
+                    }
+                )
+            )
+
+            if not valid_values:
+                # Values aren't consistent between catalogues, so default to null for the overall phenotype
+                _effects[drug].append(OrderedDict({"phenotype": None}))
+            else:
+                # Also add the most significant phenotype for this drug across all catalogues
+                most_significant_phenotype = None
+                for cat in catalogue:
+                    if drug not in cat.catalogue.drugs:
+                        continue
+                    phenotype = phenotypes.get(f"{drug} {cat.catalogue.name}")
+                    if phenotype is not None:
+                        if most_significant_phenotype is None:
+                            most_significant_phenotype = phenotype
+                        else:
+                            # Compare significance of phenotypes
+                            if values.index(phenotype) > values.index(
+                                most_significant_phenotype
+                            ):
+                                most_significant_phenotype = phenotype
+                _effects[drug].append(
+                    OrderedDict({"phenotype": most_significant_phenotype})
+                )
 
     data["effects"] = OrderedDict(
         [(key, _effects[key]) for key in sorted(_effects.keys())]

--- a/gnomonicus/gnomonicus_lib.py
+++ b/gnomonicus/gnomonicus_lib.py
@@ -12,8 +12,7 @@ import logging
 import os
 import re
 import warnings
-from collections import defaultdict, OrderedDict
-from typing import Dict, List, Tuple
+from collections import OrderedDict, defaultdict
 
 import grumpy  # type: ignore
 import pandas as pd
@@ -71,7 +70,7 @@ def parse_grumpy_evidence(evidence: grumpy.VCFRow) -> dict:
             else:
                 item = [int(v) for v in value]
         else:
-            if item is None or isinstance(item, int) or isinstance(item, float):
+            if item is None or isinstance(item, (int, float)):
                 # Should never happen but appease mypy
                 continue
             for v in value:
@@ -468,11 +467,10 @@ def write_mutations_csv(
                 row["codes_protein"]
                 and row["ref"] is not None
                 and row["alt"] is not None
+                and len(row["ref"]) == 1
             ):
-                # Protein coding so check if nucleotide within coding region
-                if len(row["ref"]) == 1:
-                    # Nucleotide SNP
-                    to_drop.append(idx2)
+                # Nucleotide SNP
+                to_drop.append(idx2)
         mutations_.drop(index=to_drop, inplace=True)
     # Save it as CSV
     mutations_.to_csv(path, index=False)
@@ -499,7 +497,7 @@ def subset_multis(
         if gene
         if not None
     ]
-    joined = set([gene + "@" + mut for (gene, mut, _) in mutations])
+    joined = {gene + "@" + mut for (gene, mut, _) in mutations}
     large_del_re = re.compile(
         r"""
         .*del_[01]\.[0-9]+.*
@@ -526,7 +524,7 @@ def subset_multis(
     )
 
     # Find these once so they aren't fetched on every iteration
-    existing_genes = set([gene for (gene, _, _) in mutations])
+    existing_genes = {gene for (gene, _, _) in mutations}
     large_dels = [
         (gene, mut, minor)
         for (gene, mut, minor) in mutations
@@ -569,17 +567,16 @@ def subset_multis(
                             promoter = False
                         matched = False
                         for g, m, minor in snps:
-                            if g == gene and (
+                            if g == gene and (  # noqa: SIM102
                                 (minor is None and not rule_is_minor)
                                 or (minor is not None and rule_is_minor)
                             ):
-                                if promoter and "-" in m:
-                                    matched = True
-                                    if minor is not None:
-                                        this_match.append(g + "@" + m + ":" + minor)
-                                    else:
-                                        this_match.append(g + "@" + m)
-                                elif not promoter and "-" not in m:
+                                if (
+                                    promoter
+                                    and "-" in m
+                                    or not promoter
+                                    and "-" not in m
+                                ):
                                     matched = True
                                     if minor is not None:
                                         this_match.append(g + "@" + m + ":" + minor)
@@ -635,9 +632,12 @@ def subset_multis(
                                     (minor is None and not rule_is_minor)
                                     or (minor is not None and rule_is_minor)
                                 ):
-                                    if promoter and "-" not in m:
-                                        continue
-                                    elif not promoter and "-" in m:
+                                    if (
+                                        promoter
+                                        and "-" not in m
+                                        or not promoter
+                                        and "-" in m
+                                    ):
                                         continue
                                     if searching in m:
                                         matched = True
@@ -668,16 +668,19 @@ def subset_multis(
                         else:
                             # Only mixed left
                             for g, m, minor in indels:
-                                if g == gene and (
-                                    (minor is None and not rule_is_minor)
-                                    or (minor is not None and rule_is_minor)
+                                if (
+                                    g == gene
+                                    and (
+                                        (minor is None and not rule_is_minor)
+                                        or (minor is not None and rule_is_minor)
+                                    )
+                                    and "mixed" in m
                                 ):
-                                    if "mixed" in m:
-                                        matched = True
-                                        if minor is not None:
-                                            this_match.append(g + "@" + m + ":" + minor)
-                                        else:
-                                            this_match.append(g + "@" + m)
+                                    matched = True
+                                    if minor is not None:
+                                        this_match.append(g + "@" + m + ":" + minor)
+                                    else:
+                                        this_match.append(g + "@" + m)
                         check = check and matched
 
                 elif "?" in mut:
@@ -752,7 +755,7 @@ def getMutations(
     mutations_df: pd.DataFrame | None,
     catalogue: piezo.ResistanceCatalogue,
     reference: grumpy.Genome,
-) -> List[Tuple[str | None, str]]:
+) -> list[tuple[str | None, str]]:
     """Get all of the mutations (including multi-mutations) from the mutations df
     Multi-mutations currently only exist within the converted WHO catalogue, and are a highly specific combination
         of mutations which must all be present for a single resistance value.
@@ -767,7 +770,7 @@ def getMutations(
     """
     if mutations_df is None:
         return []
-    mutations: List[Tuple[str | None, str]] = list(
+    mutations: list[tuple[str | None, str]] = list(
         zip(mutations_df["gene"], mutations_df["mutation"])
     )
     # Grab the multi-mutations from the catalogue
@@ -852,18 +855,17 @@ def epistasis(
     if len(epi_rules) > 0:
         # We have some epistasis rules so deal with them
         mutations = subset_multis(epi_rules, mutations, just_joined=True)
-        seen_multis = set([effects[key][2] for key in effects.keys()])
+        seen_multis = {effects[key][2] for key in effects}
         for _, mutation in mutations:
             prediction = resistanceCatalogue.predict(mutation, show_evidence=True)
             if isinstance(prediction, str):
                 # prediction == "S" but mypy doesn't like that
                 # Default prediction so ignore (not that this should happen here)
                 continue
-            for drug in prediction.keys():
+            for drug in prediction:
                 pred = prediction[drug]
                 if isinstance(pred, str):
                     # Shouldn't be hit but mypy complains
-                    pred = pred
                     evidence = None
                 else:
                     pred, evidence = pred
@@ -897,7 +899,7 @@ def populateEffects(
     reference: grumpy.Genome,
     make_mutations_csv: bool = False,
     append: bool = False,
-) -> Tuple[pd.DataFrame, Dict, pd.DataFrame] | None:
+) -> tuple[pd.DataFrame, dict, pd.DataFrame] | None:
     """Populate and save the effects DataFrame as a CSV
 
     Args:
@@ -952,13 +954,13 @@ def populateEffects(
 
         # If the prediction is interesting, iter through drugs to find predictions
         if prediction != "S" and not isinstance(prediction, str):
-            for drug in prediction.keys():
+            for drug in prediction:
                 drug_pred = prediction[drug]
                 if isinstance(drug_pred, str):
                     # This shouldn't happen because we're showing evidence
                     # Adding to appease mypy...
                     pred: str = drug_pred
-                    evidence: Dict = {}
+                    evidence: dict = {}
                 else:
                     pred, evidence = drug_pred
                 # Prioritise values based on order within the values list
@@ -1078,7 +1080,7 @@ def saveJSON(
     phenotypes: dict[str, str],
     path: str,
     guid: str,
-    catalogue: piezo.ResistanceCatalogue,
+    catalogue: list[piezo.ResistanceCatalogue],
     gnomonicusVersion: str,
     time_taken: float,
     reference: grumpy.Genome,
@@ -1169,7 +1171,7 @@ def saveJSON(
             "workflow_version": gnomonicusVersion,  # gnomonicus version used
             "workflow_task": "resistance_prediction",  # TODO: Update this when we know how to detect a virulence catalogue
             "guid": guid,  # Sample GUID
-            "UTC-datetime-completed": datetime.datetime.utcnow().isoformat(),  # ISO datetime run
+            "UTC-datetime-completed": datetime.datetime.utcnow().isoformat(),  # ISO datetime run  # noqa: DTZ003
             "time_taken_s": time_taken,
             "reference": reference.name,
             "catalogue_file": catalogue_path,
@@ -1205,7 +1207,7 @@ def saveJSON(
         values = []
 
     # Main data collection
-    data: Dict = OrderedDict()
+    data: dict = OrderedDict()
 
     # Antibigram field
     data["antibiogram"] = OrderedDict(
@@ -1303,7 +1305,7 @@ def saveJSON(
                 prediction["catalogue_name"] = effect["catalogue_name"]
             _effects[effect["drug"]].append(prediction)
 
-    for drug in _effects.keys():
+    for drug in _effects:
         _effects[drug] = sorted(
             _effects[drug],
             key=lambda x: (x["gene"] or "z", x["mutation"] or "z"),

--- a/gnomonicus/gnomonicus_table_update.py
+++ b/gnomonicus/gnomonicus_table_update.py
@@ -2,9 +2,10 @@
 """Update existing gnomonicus tables with a new catalogue."""
 
 import argparse
-import piezo
-import pandas
+
 import grumpy
+import pandas
+import piezo
 
 from gnomonicus import populateEffects
 

--- a/gnomonicus/merge_vcfs.py
+++ b/gnomonicus/merge_vcfs.py
@@ -3,11 +3,10 @@ Will only include null calls from the GVCF.
 """
 
 import argparse
-import grumpy
-
-from vcf_subset import subset_vcf
-
 from pathlib import Path
+
+import grumpy
+from vcf_subset import subset_vcf
 
 
 def fetch_minos_positions(minos_path: Path, min_dp: int) -> set[int]:
@@ -46,7 +45,7 @@ def check_gvcf_row(row: str, min_dp: int) -> bool:
         f.write(row + "\n")
     vcf = grumpy.VCFFile(".temp_gvcf_row.vcf", False, min_dp)
     valid = True
-    for position, calls in vcf.calls.items():
+    for position, calls in vcf.calls.items():  # noqa: PERF102
         for call in calls:
             if call.call_type != grumpy.AltType.NULL:
                 valid = False
@@ -86,10 +85,10 @@ def main():
 
     # Read in the resistant positions
     with open(resistant_positions_path) as f:
-        resistant_positions = set([int(line.strip()) for line in f])
+        resistant_positions = {int(line.strip()) for line in f}
 
     minos_positions = fetch_minos_positions(minos_path, args.min_dp)
-    to_fetch = sorted(list(resistant_positions - minos_positions))
+    to_fetch = sorted(resistant_positions - minos_positions)
     print(f"Fetching {len(to_fetch)} positions from the GVCF")
     # fetch_strs = set([str(pos) for pos in to_fetch])
 
@@ -120,29 +119,22 @@ def main():
         and "#CHROM" not in header
     ]
 
-    chrom_line = [header for header in minos_headers if "#CHROM" in header][0]
+    chrom_line = next(header for header in minos_headers if "#CHROM" in header)
 
     with open(output_path, "w") as f:
-        for misc in minos_misc_headers:
-            f.write(misc + "\n")
+        f.writelines(misc + "\n" for misc in minos_misc_headers)
 
         # Merged format
-        for header in minos_format:
-            f.write(header + "\n")
-        for header in missing_format:
-            f.write(header + "\n")
+        f.writelines(header + "\n" for header in minos_format)
+        f.writelines(header + "\n" for header in missing_format)
 
         # Merged info
-        for header in minos_info:
-            f.write(header + "\n")
-        for header in missing_info:
-            f.write(header + "\n")
+        f.writelines(header + "\n" for header in minos_info)
+        f.writelines(header + "\n" for header in missing_info)
 
         # Merged filter
-        for header in minos_filter:
-            f.write(header + "\n")
-        for header in missing_filter:
-            f.write(header + "\n")
+        f.writelines(header + "\n" for header in minos_filter)
+        f.writelines(header + "\n" for header in missing_filter)
 
         f.write(chrom_line + "\n")
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -68,5 +68,6 @@ disable_error_code = ["import-untyped", "import-not-found"]
 
 [tool.ruff]
 ignore = [
-    "LOG015"
+    "LOG015",
+    "SIM115",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -65,3 +65,8 @@ include = ["gnomonicus/*"]
 
 [tool.mypy]
 disable_error_code = ["import-untyped", "import-not-found"]
+
+[tool.ruff]
+ignore = [
+    "LOG015"
+]

--- a/tests/unit/test_unit.py
+++ b/tests/unit/test_unit.py
@@ -88,9 +88,9 @@ def ordered(obj):
         object: Sorted JSON
     """
     if isinstance(obj, dict):
-        if "variants" in obj.keys():
+        if "variants" in obj:
             # We have the 'data' field which needs a little extra nudge
-            if "effects" in obj.keys():
+            if "effects" in obj:
                 # Case when we have effects populated
                 return [
                     ("antibiogram", ordered(obj["antibiogram"])),
@@ -101,7 +101,7 @@ def ordered(obj):
                         sorted([ordered(x) for x in obj["variants"]], key=variants_key),
                     ),
                 ]
-            elif "mutations" in obj.keys():
+            elif "mutations" in obj:
                 # Case for if we have mutations and variants but no effects
                 return [
                     ("mutations", ordered(obj["mutations"])),
@@ -119,14 +119,14 @@ def ordered(obj):
                     )
                 ]
         else:
-            return sorted((k, ordered(obj[k])) for k in sorted(list(obj.keys())))
+            return sorted((k, ordered(obj[k])) for k in sorted(obj.keys()))
 
-    if isinstance(obj, list) or isinstance(obj, tuple):
+    if isinstance(obj, (list, tuple)):
         return sorted(ordered(x) for x in obj)
 
     # Nones cause issues with ordering as there is no < operator.
     # Convert to string to avoid this
-    if isinstance(obj, type(None)):
+    if obj is None:
         return str(obj)
 
     # Because nan types are helpful, `float('nan') == float('nan') -> False`
@@ -255,7 +255,7 @@ def test_1():
         phenotypes,
         path,
         vcfStem,
-        catalogue,
+        [catalogue],
         gnomonicus.__version__,
         -1,
         reference,
@@ -345,9 +345,9 @@ def test_1():
     variants = pd.read_csv(path + f"{vcfStem}.variants.csv")
     mutations = pd.read_csv(path + f"{vcfStem}.mutations.csv")
     # Neither of these should be populated
-    with pytest.raises(Exception):
+    with pytest.raises(FileNotFoundError):
         effects = pd.read_csv(path + f"{vcfStem}.effects.csv")
-    with pytest.raises(Exception):
+    with pytest.raises(FileNotFoundError):
         predictions = pd.read_csv(path + f"{vcfStem}.predictions.csv")
 
     gnomonicus.saveJSON(
@@ -473,7 +473,7 @@ def test_3():
 
     # Sort the mutations for comparing
     mutations_ = sorted(
-        list(zip(mutations_csv["gene"], mutations_csv["mutation"])),
+        zip(mutations_csv["gene"], mutations_csv["mutation"]),
         key=lambda x: x[0] + x[1] if x[0] is not None else x[1],
     )
     assert mutations_ == sorted(
@@ -507,7 +507,7 @@ def test_3():
         phenotypes,
         path,
         vcfStem,
-        catalogue,
+        [catalogue],
         gnomonicus.__version__,
         -1,
         reference,
@@ -687,7 +687,7 @@ def test_4():
         phenotypes,
         path,
         vcfStem,
-        catalogue,
+        [catalogue],
         gnomonicus.__version__,
         -1,
         reference,
@@ -845,7 +845,7 @@ def test_5():
         phenotypes,
         path,
         vcfStem,
-        catalogue,
+        [catalogue],
         gnomonicus.__version__,
         -1,
         reference,
@@ -998,7 +998,7 @@ def test_6():
         phenotypes,
         path,
         vcfStem,
-        catalogue,
+        [catalogue],
         gnomonicus.__version__,
         -1,
         reference,
@@ -1164,7 +1164,7 @@ def test_7():
 
     # Sort the mutations for comparing
     mutations_ = sorted(
-        list(zip(mutations["gene"], mutations["mutation"])),
+        zip(mutations["gene"], mutations["mutation"]),
         key=lambda x: x[0] + x[1] if x[0] is not None else x[1],
     )
 
@@ -1205,7 +1205,7 @@ def test_7():
         phenotypes,
         path,
         vcfStem,
-        catalogue,
+        [catalogue],
         gnomonicus.__version__,
         -1,
         reference,
@@ -1407,7 +1407,7 @@ def test_8():
         phenotypes,
         path,
         vcfStem,
-        catalogue,
+        [catalogue],
         gnomonicus.__version__,
         -1,
         reference,
@@ -1532,7 +1532,7 @@ def test_9():
 
     # Sort the mutations for comparing
     mutations_ = sorted(
-        list(zip(mutations["gene"], mutations["mutation"])),
+        zip(mutations["gene"], mutations["mutation"]),
         key=lambda x: x[0] + x[1] if x[0] is not None else x[1],
     )
     assert mutations_ == sorted(
@@ -1575,7 +1575,7 @@ def test_9():
         phenotypes,
         path,
         vcfStem,
-        catalogue,
+        [catalogue],
         gnomonicus.__version__,
         -1,
         reference,
@@ -1789,7 +1789,7 @@ def test_10():
 
     # Sort the mutations for comparing
     mutations_ = sorted(
-        list(zip(mutations["gene"], mutations["mutation"])),
+        zip(mutations["gene"], mutations["mutation"]),
         key=lambda x: x[0] + x[1] if x[0] is not None else x[1],
     )
     assert mutations_ == sorted(
@@ -1832,7 +1832,7 @@ def test_10():
         phenotypes,
         path,
         vcfStem,
-        catalogue,
+        [catalogue],
         gnomonicus.__version__,
         -1,
         reference,
@@ -2083,7 +2083,7 @@ def test_11():
         phenotypes,
         path,
         vcfStem,
-        catalogue,
+        [catalogue],
         gnomonicus.__version__,
         -1,
         reference,
@@ -2275,7 +2275,7 @@ def test_12():
 
     # Sort the mutations for comparing
     mutations_ = sorted(
-        list(zip(mutations["gene"], mutations["mutation"])),
+        zip(mutations["gene"], mutations["mutation"]),
         key=lambda x: x[0] + x[1] if x[0] is not None else x[1],
     )
 
@@ -2322,7 +2322,7 @@ def test_12():
         phenotypes,
         path,
         vcfStem,
-        catalogue,
+        [catalogue],
         gnomonicus.__version__,
         -1,
         reference,
@@ -2551,7 +2551,7 @@ def test_13():
         phenotypes,
         path,
         vcfStem,
-        catalogue,
+        [catalogue],
         gnomonicus.__version__,
         -1,
         reference,
@@ -2664,7 +2664,7 @@ def test_14():
     mutations = gnomonicus.populateMutations(
         vcfStem, path, diff, reference, sample, catalogue, True, True
     )
-    e, phenotypes, _ = gnomonicus.populateEffects(
+    _e, _phenotypes, _ = gnomonicus.populateEffects(
         path, catalogue, mutations, vcfStem, True, True, reference
     )
 
@@ -2722,7 +2722,7 @@ def test_15():
         phenotypes,
         path,
         vcfStem,
-        catalogue,
+        [catalogue],
         gnomonicus.__version__,
         -1,
         reference,
@@ -2871,7 +2871,7 @@ def test_15():
     expectedJSON = json.loads(json.dumps(expectedJSON, sort_keys=True))
 
     actualJSON = prep_json(
-        json.load(open(os.path.join(path, f"{vcfStem}.gnomonicus-out.json"), "r"))
+        json.load(open(os.path.join(path, f"{vcfStem}.gnomonicus-out.json"), "r")) 
     )
 
     # assert == does work here, but gives ugly errors if mismatch

--- a/tests/unit/test_unit.py
+++ b/tests/unit/test_unit.py
@@ -2871,7 +2871,7 @@ def test_15():
     expectedJSON = json.loads(json.dumps(expectedJSON, sort_keys=True))
 
     actualJSON = prep_json(
-        json.load(open(os.path.join(path, f"{vcfStem}.gnomonicus-out.json"), "r")) 
+        json.load(open(os.path.join(path, f"{vcfStem}.gnomonicus-out.json"), "r"))
     )
 
     # assert == does work here, but gives ugly errors if mismatch


### PR DESCRIPTION
Enables >1 catalogue to be optionally passed as a CLI argument. This builds tables with multiple catalogues at once
Within the JSON produced for >1 catalogue, the drugs in the antibiogram indicate which catalogue predicted them. Similarly, the effects block gains an extra field when needed to indicate which catalogue the effect is predicted from. The predictions block specifies per-catalogue, as well as attempting to give an overarching prioritisation (assuming the catalogues all use the same prediction values).

When running in single catalogue mode, the output JSON and tables are unchanged. 


A lot of these line changes are actually due to linting.